### PR TITLE
Modernize PoseNet to remove critical protobufjs chain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "shadowcam-front",
       "version": "0.1.0",
       "dependencies": {
-        "@tensorflow-models/posenet": "0.2.3",
-        "@tensorflow/tfjs": "0.13.0",
+        "@tensorflow-models/posenet": "2.2.2",
+        "@tensorflow/tfjs": "3.21.0",
         "bootstrap": "^4.3.1",
         "compute-cosine-similarity": "^1.0.0",
         "lodash.debounce": "^4.0.8",
@@ -3088,61 +3088,6 @@
         }
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3492,55 +3437,123 @@
       }
     },
     "node_modules/@tensorflow-models/posenet": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@tensorflow-models/posenet/-/posenet-0.2.3.tgz",
-      "integrity": "sha512-PcYnxkUW9FMPRROVk2RhE9rzxnmi0pd/psVRmhkTX76Y4BX8VArlT9S0z2yBjEG7hs/iCFsKeu98L2ahDmGZpA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@tensorflow-models/posenet/-/posenet-2.2.2.tgz",
+      "integrity": "sha512-0SXIksRet/IdX7WVH+JSD6W3upkGHix1hwtd3xykIoIMGR7zQ4SC5+wZcNt9ofASyxNYQoI+tUULUo4LNw0c3w==",
+      "license": "Apache-2.0",
       "peerDependencies": {
-        "@tensorflow/tfjs": "^0.13.0"
+        "@tensorflow/tfjs-converter": "^3.0.0-rc.1",
+        "@tensorflow/tfjs-core": "^3.0.0-rc.1"
       }
     },
     "node_modules/@tensorflow/tfjs": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-0.13.0.tgz",
-      "integrity": "sha512-HOx+bfMRe1Fj0X9m0ctt7WYARgdiHsywDA9nPv7IZopWNQZxoR8ey1sef24eeBiJdtjKDCaAqlsLID7XEYmqdQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.21.0.tgz",
+      "integrity": "sha512-khcARd3/872llL/oF4ouR40qlT71mylU66PGT8kHP/GJ5YKj44sv8lDRjU7lOVlJK7jsJFWEsNVHI3eMc/GWNQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@tensorflow/tfjs-converter": "0.6.0",
-        "@tensorflow/tfjs-core": "0.13.0",
-        "@tensorflow/tfjs-layers": "0.8.0"
+        "@tensorflow/tfjs-backend-cpu": "3.21.0",
+        "@tensorflow/tfjs-backend-webgl": "3.21.0",
+        "@tensorflow/tfjs-converter": "3.21.0",
+        "@tensorflow/tfjs-core": "3.21.0",
+        "@tensorflow/tfjs-data": "3.21.0",
+        "@tensorflow/tfjs-layers": "3.21.0",
+        "argparse": "^1.0.10",
+        "chalk": "^4.1.0",
+        "core-js": "3",
+        "regenerator-runtime": "^0.13.5",
+        "yargs": "^16.0.3"
+      },
+      "bin": {
+        "tfjs-custom-module": "dist/tools/custom_module/cli.js"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-backend-cpu": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.21.0.tgz",
+      "integrity": "sha512-88S21UAdzyK0CsLUrH17GPTD+26E85OP9CqmLZslaWjWUmBkeTQ5Zqyp6iK+gELnLxPx6q7JsNEeFuPv4254lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/seedrandom": "^2.4.28",
+        "seedrandom": "^3.0.5"
+      },
+      "engines": {
+        "yarn": ">= 1.3.2"
+      },
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "3.21.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-backend-webgl": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.21.0.tgz",
+      "integrity": "sha512-N4zitIAT9IX8B8oe489qM3f3VcESxGZIZvHmVP8varOQakTvTX859aaPo1s8hK1qCy4BjSGbweooZe4U8D4kTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tensorflow/tfjs-backend-cpu": "3.21.0",
+        "@types/offscreencanvas": "~2019.3.0",
+        "@types/seedrandom": "^2.4.28",
+        "@types/webgl-ext": "0.0.30",
+        "@types/webgl2": "0.0.6",
+        "seedrandom": "^3.0.5"
+      },
+      "engines": {
+        "yarn": ">= 1.3.2"
+      },
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "3.21.0"
       }
     },
     "node_modules/@tensorflow/tfjs-converter": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.0.tgz",
-      "integrity": "sha512-V79mLYmwVwdWNjB0qzf6op/0G2ux1uyMYMcw4nFrJEvgL+Mwsu/6CjcUAslIriobWtZZUiwodcEHZckxYy8Fig==",
-      "dependencies": {
-        "@types/long": "~3.0.32",
-        "protobufjs": "~6.8.6"
-      },
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.21.0.tgz",
+      "integrity": "sha512-12Y4zVDq3yW+wSjSDpSv4HnpL2sDZrNiGSg8XNiDE4HQBdjdA+a+Q3sZF/8NV9y2yoBhL5L7V4mMLDdbZBd9/Q==",
+      "license": "Apache-2.0",
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "~0.13.0"
+        "@tensorflow/tfjs-core": "3.21.0"
       }
     },
     "node_modules/@tensorflow/tfjs-core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-0.13.0.tgz",
-      "integrity": "sha512-0o0WlHFB82GMtjcT/ozyxu85iXM3Ao7wCzlTdEvyefqY4pcIQc8HJ/5lG+XDn3tII8N2LxJvVYn6SYQjG+Cjig==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.21.0.tgz",
+      "integrity": "sha512-YSfsswOqWfd+M4bXIhT3hwtAb+IV8+ODwIxwdFR/7jTAPZP1wMVnSlpKnXHAN64HFOiP+Tm3HmKusEZ0+09A0w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/seedrandom": "~2.4.27",
-        "@types/webgl-ext": "~0.0.29",
-        "@types/webgl2": "~0.0.4",
-        "seedrandom": "~2.4.3"
+        "@types/long": "^4.0.1",
+        "@types/offscreencanvas": "~2019.3.0",
+        "@types/seedrandom": "^2.4.28",
+        "@types/webgl-ext": "0.0.30",
+        "@webgpu/types": "0.1.16",
+        "long": "4.0.0",
+        "node-fetch": "~2.6.1",
+        "seedrandom": "^3.0.5"
       },
       "engines": {
         "yarn": ">= 1.3.2"
       }
     },
-    "node_modules/@tensorflow/tfjs-layers": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.0.tgz",
-      "integrity": "sha512-UicXHEUTc4Se10dhpqmBhYug074ZADR+8KaYT61fay9AcqjLEQTCgmmDJpxOFJ9zq8W0oBh8QAK7wyKS62tx+w==",
+    "node_modules/@tensorflow/tfjs-data": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.21.0.tgz",
+      "integrity": "sha512-eFLfw2wIcFNxnP2Iv/SnVlihehzKMumk1b5Prcx1ixk/SbkCo5u0Lt7OVOWaEOKVqvB2sT+dJcTjAh6lrCC/QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node-fetch": "^2.1.2",
+        "node-fetch": "~2.6.1",
+        "string_decoder": "^1.3.0"
+      },
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "0.13.0"
+        "@tensorflow/tfjs-core": "3.21.0",
+        "seedrandom": "^3.0.5"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-layers": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.21.0.tgz",
+      "integrity": "sha512-CMVXsraakXgnXEnqD9QbtResA7nvV7Jz20pGmjFIodcQkClgmFFhdCG5N+zlVRHEz7VKG2OyfhltZ0dBq/OAhA==",
+      "license": "Apache-2.0 AND MIT",
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "3.21.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -3750,9 +3763,10 @@
       "license": "MIT"
     },
     "node_modules/@types/long": {
-      "version": "3.0.32",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-      "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -3765,6 +3779,32 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
       "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg=="
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/node-forge": {
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
@@ -3773,6 +3813,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.3.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.3.0.tgz",
+      "integrity": "sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==",
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -3820,9 +3866,10 @@
       "license": "MIT"
     },
     "node_modules/@types/seedrandom": {
-      "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.28.tgz",
-      "integrity": "sha512-SMA+fUwULwK7sd/ZJicUztiPs8F1yCPwF3O23Z9uQ32ME5Ha0NmDK9+QTsYE4O2tHXChzXomSWWeIhCnoN1LqA=="
+      "version": "2.4.34",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.34.tgz",
+      "integrity": "sha512-ytDiArvrn/3Xk6/vtylys5tlY6eo7Ane0hvcx++TKo6RxQXuVfW0AF/oeWqAj9dN29SyhtawuXstgmPlwNcv/A==",
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -3893,12 +3940,14 @@
     "node_modules/@types/webgl-ext": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/webgl-ext/-/webgl-ext-0.0.30.tgz",
-      "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
+      "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==",
+      "license": "MIT"
     },
     "node_modules/@types/webgl2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz",
-      "integrity": "sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.6.tgz",
+      "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -4340,6 +4389,12 @@
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.16.tgz",
+      "integrity": "sha512-9E61voMP4+Rze02jlTXud++Htpjyyk8vw5Hyw9FGRrmhHQg2GqbuOfwf5Klrb8vTxc2XWI3EfO7RUHMpxTj26A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -12212,7 +12267,8 @@
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -12591,6 +12647,48 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -14711,42 +14809,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "6.8.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
-      "integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
-    "node_modules/protobufjs/node_modules/@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
-    },
-    "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "10.14.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
-      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -16143,9 +16205,10 @@
       "license": "MIT"
     },
     "node_modules/seedrandom": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
-      "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -16688,12 +16751,33 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@tensorflow-models/posenet": "0.2.3",
-    "@tensorflow/tfjs": "0.13.0",
+    "@tensorflow-models/posenet": "2.2.2",
+    "@tensorflow/tfjs": "3.21.0",
     "bootstrap": "^4.3.1",
     "compute-cosine-similarity": "^1.0.0",
     "lodash.debounce": "^4.0.8",

--- a/src/__tests__/pages/NewRecordingPage/NewRecordingPage.js
+++ b/src/__tests__/pages/NewRecordingPage/NewRecordingPage.js
@@ -1,10 +1,19 @@
 import React from "react";
 import { shallow } from "enzyme";
+import * as posenet from "@tensorflow-models/posenet";
+import * as tf from "@tensorflow/tfjs";
 import { NewRecordingPage } from "../../../pages/NewRecordingPage/NewRecordingPage";
+import { processPose } from "../../../utils/poseUtils";
 
 jest.mock("@tensorflow-models/posenet", () => {
   return {
-    load: jest.fn(() => {})
+    load: jest.fn()
+  };
+});
+
+jest.mock("../../../utils/poseUtils", () => {
+  return {
+    processPose: jest.fn()
   };
 });
 
@@ -42,6 +51,70 @@ describe("NewRecordingPage render", () => {
 });
 
 describe("NewRecordingPage start training tests", () => {
+  it("Should load and run the configured PoseNet model", async () => {
+    const keypointParts = [
+      "nose",
+      "leftEye",
+      "rightEye",
+      "leftEar",
+      "rightEar",
+      "leftShoulder",
+      "rightShoulder",
+      "leftElbow",
+      "rightElbow",
+      "leftWrist",
+      "rightWrist",
+      "leftHip",
+      "rightHip",
+      "leftKnee",
+      "rightKnee",
+      "leftAnkle",
+      "rightAnkle"
+    ];
+    const pose = {
+      score: 0.9,
+      keypoints: keypointParts.map((part, index) => ({
+        score: 0.9,
+        part,
+        position: { x: index, y: index + 1 }
+      }))
+    };
+    const estimateSinglePose = jest.fn().mockResolvedValue(pose);
+    posenet.load.mockResolvedValue({ estimateSinglePose });
+    processPose.mockReturnValue("noPunch");
+
+    const spy = jest.spyOn(NewRecordingPage.prototype, "componentDidMount");
+    spy.mockImplementation(() => {});
+    const wrapper = shallow(<NewRecordingPage />);
+    const instance = wrapper.instance();
+    instance.mediaRecorder = { state: "inactive" };
+    instance.videoRef.current = { height: 480, width: 640 };
+    wrapper.setState({ recorderSetup: true, trainingState: "stopped" });
+
+    await tf.setBackend("cpu");
+    await tf.ready();
+    await instance.processPoses();
+
+    expect(tf.getBackend()).toBe("cpu");
+    expect(posenet.load).toHaveBeenCalledWith({
+      architecture: "MobileNetV1",
+      inputResolution: { height: 225, width: 305 },
+      multiplier: 0.75,
+      outputStride: 16
+    });
+    expect(estimateSinglePose).toHaveBeenCalledWith(
+      instance.videoRef.current,
+      { flipHorizontal: true }
+    );
+    expect(processPose).toHaveBeenCalledWith(pose);
+    expect(pose.keypoints).toHaveLength(17);
+    expect(pose.keypoints[0]).toEqual({
+      score: 0.9,
+      part: "nose",
+      position: { x: 0, y: 1 }
+    });
+  });
+
   it("Should set training state to running when called", () => {
     Object.defineProperty(window.navigator, "mediaDevices", {
       value: {

--- a/src/pages/NewRecordingPage/NewRecordingPage.js
+++ b/src/pages/NewRecordingPage/NewRecordingPage.js
@@ -8,6 +8,7 @@ import Layout from "../../components/Layout/Layout";
 import RestModal from "../../components/RestModal/RestModal";
 import { formatTimeFromSeconds } from "../../utils/utils";
 
+import "@tensorflow/tfjs";
 import * as posenet from "@tensorflow-models/posenet";
 import { processPose } from "../../utils/poseUtils";
 
@@ -288,7 +289,24 @@ export class NewRecordingPage extends Component {
   // open pose logic for processing a frame from the
   // video element
   processPoses = async () => {
-    const net = await posenet.load(0.75);
+    const toLegacyScaledResolution = dimension => {
+      const scaledResolution =
+        dimension * this.state.poseNet.imageScaleFactor - 1;
+      return (
+        scaledResolution -
+        (scaledResolution % this.state.poseNet.outputStride) +
+        1
+      );
+    };
+    const net = await posenet.load({
+      architecture: "MobileNetV1",
+      inputResolution: {
+        width: toLegacyScaledResolution(this.state.width),
+        height: toLegacyScaledResolution(this.state.height)
+      },
+      multiplier: 0.75,
+      outputStride: this.state.poseNet.outputStride
+    });
 
     // keep the state from updating constantly once it finds
     // a correct punch pose
@@ -307,12 +325,9 @@ export class NewRecordingPage extends Component {
       // startTime = +new Date()
       let pose;
       if (this.state.recorderSetup) {
-        pose = await net.estimateSinglePose(
-          this.videoRef.current,
-          this.state.poseNet.imageScaleFactor,
-          this.state.poseNet.flipHorizontal,
-          this.state.poseNet.outputStride
-        );
+        pose = await net.estimateSinglePose(this.videoRef.current, {
+          flipHorizontal: this.state.poseNet.flipHorizontal
+        });
         const punchType = processPose(pose);
         if (punchType && punchType !== "noPunch") {
           debounceUpdateState(punchType);
@@ -326,7 +341,7 @@ export class NewRecordingPage extends Component {
       // console.log(+new Date() - startTime);
     };
 
-    poseDetectionFrame();
+    return poseDetectionFrame();
   };
 
   // play a recorded video on video element


### PR DESCRIPTION
## What changed
- upgrade PoseNet from 0.2.3 to 2.2.2
- upgrade TensorFlow.js from 0.13.0 to the compatible 3.21.0 line
- migrate legacy positional model-load and inference calls to PosNet 2 configuration objects
- preserve MobileNet multiplier 0.75, output stride 16, flip behavior, and the legacy effective 305x225 input resolution
- add focused model configuration and representative 17-keypoint inference coverage

## Why
The legacy TensorFlow converter installed vulnerable `protobufjs`, including a critical advisory. The supported TFJS 3.21/PosNet 2.2 pair removes that dependency while keeping a single deduplicated TensorFlow engine.

## Validation
- `npm ci`
- `npm ls --all`
- TensorFlow graph guard: Core, Converter, CPU, and WebGL resolve once at 3.21.0
- unmocked CPU MobileNet inference returned 17 keypoints without platform-overwrite warnings
- `npm run test:nowatch -- --runInBand --detectOpenHandles`: 12 suites, 83 tests, 10 snapshots passed
- `npm run build`
- `npm audit --json`: 0 critical, 11 high; every remaining high belongs to the separate CRA migration
- confirmed `protobufjs` and `@protobufjs/*` are absent
- independent review passed

## Breaking-change note
This updates two direct dependencies across major versions and changes their initialization API. Application-level pose configuration and output handoff are covered, but real camera/WebGL execution remains a browser smoke-test concern.

## Risk and rollback
The modern TensorFlow bundle is larger than the legacy build. The pre-existing model lifecycle also reloads models on resume/rest without explicit disposal. Roll back by reverting this PR; no data migration is involved.